### PR TITLE
Change build target to ES5

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,10 +19,7 @@
   "scripts": {
     "prettier": "prettier --ignore-path .gitignore --write 'src/**/*.{ts,tsx,js,jsx}'",
     "prettier:diff": "prettier -l 'src/**/*.{ts,tsx,js,jsx}'",
-    "prepush": "yarn prettier:diff",
-    "precommit": "pretty-quick --staged && yarn tslint",
     "tslint": "tslint 'src/**/*.{js,jsx,ts,tsx}' -t verbose",
-    "commitmsg": "commitlint -E GIT_PARAMS",
     "clean": "rimraf lib",
     "build": "tsc",
     "test": "jest --no-cache --config='jest.config.js'",
@@ -68,6 +65,13 @@
   "config": {
     "commitizen": {
       "path": "git-cz"
+    }
+  },
+  "husky": {
+    "hooks": {
+      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
+      "pre-commit": "pretty-quick --staged && yarn tslint",
+      "pre-push": "yarn prettier:diff"
     }
   }
 }

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -2,8 +2,8 @@ import {setHarmonicInterval, clearHarmonicInterval} from '..';
 
 jest.useFakeTimers();
 
-const setIntervalSpy = setInterval as any as jest.SpyInstance;
-const clearIntervalSpy = clearInterval as any as jest.SpyInstance;
+const setIntervalSpy = (setInterval as any) as jest.SpyInstance;
+const clearIntervalSpy = (clearInterval as any) as jest.SpyInstance;
 
 beforeEach(() => {
   setIntervalSpy.mockReset();

--- a/src/__tests__/real-timers.spec.ts
+++ b/src/__tests__/real-timers.spec.ts
@@ -9,12 +9,12 @@ test('calls timer', async () => {
 
   expect(spy).toHaveBeenCalledTimes(0);
 
-  await new Promise(r => setTimeout(r, 5));
+  await new Promise((r) => setTimeout(r, 5));
   expect(spy).toHaveBeenCalledTimes(1);
 
   clearHarmonicInterval(ref);
 
-  await new Promise(r => setTimeout(r, 6));
+  await new Promise((r) => setTimeout(r, 6));
   expect(spy).toHaveBeenCalledTimes(1);
 });
 
@@ -23,13 +23,13 @@ test('calls all callbacks at the same time, and clears', async () => {
   const spy2 = jest.fn();
 
   const ref1 = setHarmonicInterval(spy1, 30);
-  await new Promise(r => setTimeout(r, 15));
+  await new Promise((r) => setTimeout(r, 15));
   const ref2 = setHarmonicInterval(spy2, 30);
 
   expect(spy1).toHaveBeenCalledTimes(0);
   expect(spy2).toHaveBeenCalledTimes(0);
 
-  await new Promise(r => setTimeout(r, 16));
+  await new Promise((r) => setTimeout(r, 16));
 
   expect(spy1).toHaveBeenCalledTimes(1);
   expect(spy2).toHaveBeenCalledTimes(1);
@@ -37,7 +37,7 @@ test('calls all callbacks at the same time, and clears', async () => {
   clearHarmonicInterval(ref1);
   clearHarmonicInterval(ref2);
 
-  await new Promise(r => setTimeout(r, 31));
+  await new Promise((r) => setTimeout(r, 31));
 
   expect(spy1).toHaveBeenCalledTimes(1);
   expect(spy2).toHaveBeenCalledTimes(1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ const buckets: Record<number, Bucket> = {};
 export const setHarmonicInterval = (fn: Listener, ms: number): TimerReference => {
   const id = counter++;
 
-  if (buckets[ms]) {  
+  if (buckets[ms]) {
     buckets[ms].listeners[id] = fn;
   } else {
     const timer = setInterval(() => {
@@ -37,7 +37,7 @@ export const setHarmonicInterval = (fn: Listener, ms: number): TimerReference =>
 
       if (didThrow) throw lastError;
     }, ms);
-    
+
     buckets[ms] = {
       ms,
       timer,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "es5",
     "module": "commonjs",
     "moduleResolution": "Node",
     "removeComments": true,


### PR DESCRIPTION
Update build target from ES8 to ES5 to fix this IE11 issue in `react-use`:
https://github.com/streamich/react-use/issues/575

Husky hooks also had to be updated, and prettier needed to be run to pass husky checks.