### PR TITLE
feat: better error handling + optimization

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,9 @@ export type ClearHarmonicInterval = () => void;
 
 export interface Bucket {
   ms: number;
-  timer: any;
-  listeners: Record<number, Listener>;
+  timer: ReturnType<typeof setInterval>;
+  listeners: Map<number, Listener>;
+  listenerCount: number;
 }
 
 export interface TimerReference {
@@ -19,31 +20,36 @@ export const setHarmonicInterval = (fn: Listener, ms: number): TimerReference =>
   const id = counter++;
 
   if (buckets[ms]) {
-    buckets[ms].listeners[id] = fn;
+    buckets[ms].listeners.set(id, fn);
+    buckets[ms].listenerCount++;
   } else {
     const timer = setInterval(() => {
       const {listeners} = buckets[ms];
       let didThrow = false;
-      let lastError: any;
+      const errors: Record<number, { error: Error, listener: string, ms: number }> = {};
 
-      for (const listener of Object.values(listeners)) {
+      for (const [listenerID, listener] of listeners.entries()) {
         try {
           listener();
         } catch (error) {
           didThrow = true;
-          lastError = error;
+          const _id = Number(listenerID);
+          if (!isNaN(_id)) errors[_id] = {
+            error: error as unknown as Error,
+            listener: listener.name,
+            ms,
+          };
         }
       }
 
-      if (didThrow) throw lastError;
+      if (didThrow) throw errors;
     }, ms);
 
     buckets[ms] = {
       ms,
       timer,
-      listeners: {
-        [id]: fn,
-      },
+      listeners: new Map([[id, fn]]),
+      listenerCount: 1,
     };
   }
 
@@ -54,15 +60,12 @@ export const setHarmonicInterval = (fn: Listener, ms: number): TimerReference =>
 };
 
 export const clearHarmonicInterval = ({bucket, id}: TimerReference): void => {
-  delete bucket.listeners[id];
-
-  let hasListeners = false;
-  for (const listener in bucket.listeners) {
-    hasListeners = true;
-    break;
+  if (bucket.listeners.has(id)) {
+    bucket.listeners.delete(id);
+    bucket.listenerCount--;
   }
 
-  if (!hasListeners) {
+  if (bucket.listenerCount === 0) {
     clearInterval(bucket.timer);
     delete buckets[bucket.ms];
   }


### PR DESCRIPTION
1. return an object containing every error that was thrown by each listener. leads to better dx in case a bucket with n > 1 listeners fails due to an issue in any listener except the n-th listener.
2. use `Map` instead of an object for listeners, for two reasons:
  a. maps work better with numeric and mixed keys, objects need to convert number keys to strings internally. this adds overhead.
  b. maps guarantee order, constant-time perf & constant memory usage.
4. add a check for listener before deleting it, and use `listenerCount` to track size of `listeners`. although both this and the original implementation are O(1), this is more readable imo.